### PR TITLE
Fix(workflow): Update binary name to use underscore

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Verify Binary Exists
         run: |
-          if [ ! -f target/release/messy-folder-reorganizer-ai ]; then
+          if [ ! -f target/release/messy_folder_reorganizer_ai ]; then
             echo "Error: Binary not found!"
             exit 1
           fi
@@ -35,12 +35,12 @@ jobs:
       - name: Copy Binary
         run: |
           mkdir -p release
-          cp target/release/messy-folder-reorganizer-ai release/
+          cp target/release/messy_folder_reorganizer_ai release/
 
       - name: Package Binary
         run: |
           tar -czvf messy-folder-reorganizer-ai-${{ env.VERSION }}-x86_64-unknown-linux-gnu.tar.gz \
-            -C release messy-folder-reorganizer-ai
+            -C release messy_folder_reorganizer_ai
 
       - name: Upload Release Binaries
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Adjusts the GitHub Actions release workflow to look for `messy_folder_reorganizer_ai` (with an underscore) instead of `messy-folder-reorganizer-ai` (with a hyphen).

This change is based on troubleshooting steps for a "binary not found" error during the release build, aligning the workflow with a potential naming discrepancy where the compiled binary name might directly reflect the `Cargo.toml` package name.